### PR TITLE
Implement some missing APIs.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   [ "GONG Chen <chen.sst@gmail.com> (https://github.com/lotem)"
   ]
 , "description" : "marisa-trie for Node.js"
-, "version" : "0.1.1"
+, "version" : "0.1.2"
 , "repository" :
   { "type" : "git"
   , "url" : "http://github.com/komiya-atsushi/node-marisa-trie.git"

--- a/src/agent_wrapper.cc
+++ b/src/agent_wrapper.cc
@@ -120,8 +120,8 @@ Handle<Value> AgentWrap::SetQuery1(HandleScope& scope, AgentWrap *inst, String::
 }
 
 Handle<Value> AgentWrap::SetQuery2(HandleScope& scope, AgentWrap *inst, int32_t arg0) {
-  // TODO ここに実装コードを記述します。
-
+  // Reverse lookup the key with key_id.
+  inst->agent_.set_query(static_cast<uint32_t>(arg0));
   return Undefined();
 }
 

--- a/src/trie_wrapper.cc
+++ b/src/trie_wrapper.cc
@@ -2,6 +2,8 @@
 #include "keyset_wrapper.h"
 #include "agent_wrapper.h"
 
+#include <node_buffer.h>
+
 using namespace v8;
 using namespace node;
 
@@ -21,6 +23,7 @@ void TrieWrap::Init(Handle<Object> target) {
 
   NODE_SET_PROTOTYPE_METHOD(tpl, "build", TrieWrap::Build);
   NODE_SET_PROTOTYPE_METHOD(tpl, "mmap", TrieWrap::Mmap);
+  NODE_SET_PROTOTYPE_METHOD(tpl, "map", TrieWrap::Map);
   NODE_SET_PROTOTYPE_METHOD(tpl, "load", TrieWrap::Load);
   NODE_SET_PROTOTYPE_METHOD(tpl, "save", TrieWrap::Save);
   NODE_SET_PROTOTYPE_METHOD(tpl, "lookup", TrieWrap::Lookup);
@@ -93,6 +96,20 @@ Handle<Value> TrieWrap::Mmap(const Arguments& args) {
     TrieWrap *inst = ObjectWrap::Unwrap<TrieWrap>(args.This());
     String::Utf8Value arg0(args[0]->ToString());
     inst->trie_.mmap(*arg0);
+
+    return Undefined();
+  }
+
+  return ThrowException(Exception::Error(String::New("Wrong argument(s).")));
+}
+
+Handle<Value> TrieWrap::Map(const Arguments& args) {
+  HandleScope scope;
+
+  if (args.Length() == 1 && Buffer::HasInstance(args[0])) {
+    TrieWrap *inst = ObjectWrap::Unwrap<TrieWrap>(args.This());
+    Local<Object> buffer = args[0]->ToObject();
+    inst->trie_.map(Buffer::Data(buffer), Buffer::Length(buffer));
 
     return Undefined();
   }

--- a/src/trie_wrapper.h
+++ b/src/trie_wrapper.h
@@ -18,6 +18,7 @@ private:
   static v8::Handle<v8::Value> New(const v8::Arguments& args);
   static v8::Handle<v8::Value> Build(const v8::Arguments& args);
   static v8::Handle<v8::Value> Mmap(const v8::Arguments& args);
+  static v8::Handle<v8::Value> Map(const v8::Arguments& args);
   static v8::Handle<v8::Value> Load(const v8::Arguments& args);
   static v8::Handle<v8::Value> Save(const v8::Arguments& args);
   static v8::Handle<v8::Value> Lookup(const v8::Arguments& args);


### PR DESCRIPTION
Implement Agent.set_query(key_id) for reverse lookup, and Trie.map(buffer) to load trie from an existing buffer in memory.
I wrote a script to test these features: https://gist.github.com/lotem/3aad0a2f77f990278cad

That's all I need for now. I can keep going writing my node app. I'll show you a demo when I finish, if you are interested! It's a cross-platform desktop app packaged with node runtime and all the needed modules, so I do not need my users to do `npm install` from the npm repository. Take your time for code review.

Thanks.
